### PR TITLE
[IAP]Implement the in-app purchase extension on iOS

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,5 +8,6 @@ use_frameworks!
 workspace 'iOSExtensions'
 xcodeproj 'extensions/Cordova/Cordova'
 xcodeproj 'extensions/Presentation/Presentation'
+xcodeproj 'extensions/InAppPurchase/InAppPurchase'
 
 pod 'crosswalk-ios', '~> 1.2'

--- a/crosswalk-extension-iap.podspec
+++ b/crosswalk-extension-iap.podspec
@@ -1,0 +1,23 @@
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+Pod::Spec.new do |s|
+  s.name             = 'crosswalk-extension-iap'
+  s.version          = '1.0'
+  s.summary          = 'IAP extension is a Crosswalk extension which implements the in-app purchase on iOS'
+  s.homepage         = 'https://github.com/crosswalk-project/ios-extensions-crosswalk/tree/master/extensions/InAppPurchase'
+  s.license          = { :type => 'BSD', :file => "LICENSE" }
+  s.author           = { 'Minggang Wang' => 'minggang.wang@intel.com' }
+  s.source           = { :git => 'https://github.com/crosswalk-project/ios-extensions-crosswalk.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/xwalk_project'
+
+  s.platform = :ios, '8.1'
+  s.ios.deployment_target = '8.1'
+  s.module_name = 'InAppPurchase'
+  s.dependency 'crosswalk-ios', '~> 1.2'
+
+  s.source_files = 'extensions/InAppPurchase/InAppPurchase/*.{h,m,swift}'
+  s.resource = 'extensions/InAppPurchase/InAppPurchase/*.js', 'extensions/InAppPurchase/InAppPurchase/extensions.plist'
+
+end

--- a/extensions/InAppPurchase/InAppPurchase.xcodeproj/project.pbxproj
+++ b/extensions/InAppPurchase/InAppPurchase.xcodeproj/project.pbxproj
@@ -1,0 +1,392 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		572DBB551C1A912900AF0D8F /* InAppPurchase.h in Headers */ = {isa = PBXBuildFile; fileRef = 572DBB541C1A912900AF0D8F /* InAppPurchase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		572DBB681C1A917600AF0D8F /* PaymentTransactionHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 572DBB5E1C1A917600AF0D8F /* PaymentTransactionHelper.h */; };
+		572DBB691C1A917600AF0D8F /* PaymentTransactionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 572DBB5F1C1A917600AF0D8F /* PaymentTransactionHelper.m */; };
+		572DBB6A1C1A917600AF0D8F /* ProductsRequestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 572DBB601C1A917600AF0D8F /* ProductsRequestHelper.h */; };
+		572DBB6B1C1A917600AF0D8F /* ProductsRequestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 572DBB611C1A917600AF0D8F /* ProductsRequestHelper.m */; };
+		572DBB6C1C1A917600AF0D8F /* ReceiptHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 572DBB621C1A917600AF0D8F /* ReceiptHelper.h */; };
+		572DBB6D1C1A917600AF0D8F /* ReceiptHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 572DBB631C1A917600AF0D8F /* ReceiptHelper.m */; };
+		572DBB6E1C1A917600AF0D8F /* InAppPurchaseExtension.js in Resources */ = {isa = PBXBuildFile; fileRef = 572DBB641C1A917600AF0D8F /* InAppPurchaseExtension.js */; };
+		572DBB6F1C1A917600AF0D8F /* extensions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 572DBB651C1A917600AF0D8F /* extensions.plist */; };
+		579502D21C212AF400EEC9F2 /* InAppPurchaseExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 579502D01C212AF400EEC9F2 /* InAppPurchaseExtension.h */; };
+		579502D31C212AF400EEC9F2 /* InAppPurchaseExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 579502D11C212AF400EEC9F2 /* InAppPurchaseExtension.m */; };
+		C7C775F82B472E2CC42311F7 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AAD85885851186AF54DB8D5 /* Pods.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4AAD85885851186AF54DB8D5 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		572DBB511C1A912900AF0D8F /* InAppPurchase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = InAppPurchase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		572DBB541C1A912900AF0D8F /* InAppPurchase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InAppPurchase.h; sourceTree = "<group>"; };
+		572DBB561C1A912900AF0D8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		572DBB5E1C1A917600AF0D8F /* PaymentTransactionHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaymentTransactionHelper.h; sourceTree = "<group>"; };
+		572DBB5F1C1A917600AF0D8F /* PaymentTransactionHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PaymentTransactionHelper.m; sourceTree = "<group>"; };
+		572DBB601C1A917600AF0D8F /* ProductsRequestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProductsRequestHelper.h; sourceTree = "<group>"; };
+		572DBB611C1A917600AF0D8F /* ProductsRequestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProductsRequestHelper.m; sourceTree = "<group>"; };
+		572DBB621C1A917600AF0D8F /* ReceiptHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReceiptHelper.h; sourceTree = "<group>"; };
+		572DBB631C1A917600AF0D8F /* ReceiptHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReceiptHelper.m; sourceTree = "<group>"; };
+		572DBB641C1A917600AF0D8F /* InAppPurchaseExtension.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = InAppPurchaseExtension.js; sourceTree = "<group>"; };
+		572DBB651C1A917600AF0D8F /* extensions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = extensions.plist; sourceTree = "<group>"; };
+		579502D01C212AF400EEC9F2 /* InAppPurchaseExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InAppPurchaseExtension.h; sourceTree = "<group>"; };
+		579502D11C212AF400EEC9F2 /* InAppPurchaseExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InAppPurchaseExtension.m; sourceTree = "<group>"; };
+		A5CC6E7F0F100DA173AEFCC4 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "../../Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		BEFCD30CE59A1AA5215F83D1 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "../../Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		572DBB4D1C1A912900AF0D8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C7C775F82B472E2CC42311F7 /* Pods.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		572DBB471C1A912900AF0D8F = {
+			isa = PBXGroup;
+			children = (
+				572DBB531C1A912900AF0D8F /* InAppPurchase */,
+				572DBB521C1A912900AF0D8F /* Products */,
+				EE7C3759A45D8317FE0AD5FD /* Pods */,
+				7BFAD80CA45B5D3B0C8D5C01 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		572DBB521C1A912900AF0D8F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				572DBB511C1A912900AF0D8F /* InAppPurchase.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		572DBB531C1A912900AF0D8F /* InAppPurchase */ = {
+			isa = PBXGroup;
+			children = (
+				572DBB701C1A944800AF0D8F /* Supporting Files */,
+				579502D01C212AF400EEC9F2 /* InAppPurchaseExtension.h */,
+				579502D11C212AF400EEC9F2 /* InAppPurchaseExtension.m */,
+				572DBB541C1A912900AF0D8F /* InAppPurchase.h */,
+				572DBB5E1C1A917600AF0D8F /* PaymentTransactionHelper.h */,
+				572DBB5F1C1A917600AF0D8F /* PaymentTransactionHelper.m */,
+				572DBB601C1A917600AF0D8F /* ProductsRequestHelper.h */,
+				572DBB611C1A917600AF0D8F /* ProductsRequestHelper.m */,
+				572DBB621C1A917600AF0D8F /* ReceiptHelper.h */,
+				572DBB631C1A917600AF0D8F /* ReceiptHelper.m */,
+				572DBB641C1A917600AF0D8F /* InAppPurchaseExtension.js */,
+				572DBB651C1A917600AF0D8F /* extensions.plist */,
+			);
+			path = InAppPurchase;
+			sourceTree = "<group>";
+		};
+		572DBB701C1A944800AF0D8F /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				572DBB561C1A912900AF0D8F /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		7BFAD80CA45B5D3B0C8D5C01 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4AAD85885851186AF54DB8D5 /* Pods.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EE7C3759A45D8317FE0AD5FD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				BEFCD30CE59A1AA5215F83D1 /* Pods.debug.xcconfig */,
+				A5CC6E7F0F100DA173AEFCC4 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		572DBB4E1C1A912900AF0D8F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				572DBB6C1C1A917600AF0D8F /* ReceiptHelper.h in Headers */,
+				572DBB551C1A912900AF0D8F /* InAppPurchase.h in Headers */,
+				572DBB681C1A917600AF0D8F /* PaymentTransactionHelper.h in Headers */,
+				579502D21C212AF400EEC9F2 /* InAppPurchaseExtension.h in Headers */,
+				572DBB6A1C1A917600AF0D8F /* ProductsRequestHelper.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		572DBB501C1A912900AF0D8F /* InAppPurchase */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 572DBB591C1A912900AF0D8F /* Build configuration list for PBXNativeTarget "InAppPurchase" */;
+			buildPhases = (
+				CB02F3C729B4AFF194701126 /* Check Pods Manifest.lock */,
+				572DBB4C1C1A912900AF0D8F /* Sources */,
+				572DBB4D1C1A912900AF0D8F /* Frameworks */,
+				572DBB4E1C1A912900AF0D8F /* Headers */,
+				572DBB4F1C1A912900AF0D8F /* Resources */,
+				407AF654FA0576D5AFD2A4F7 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InAppPurchase;
+			productName = InAppPurchase;
+			productReference = 572DBB511C1A912900AF0D8F /* InAppPurchase.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		572DBB481C1A912900AF0D8F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = intel;
+				TargetAttributes = {
+					572DBB501C1A912900AF0D8F = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = 572DBB4B1C1A912900AF0D8F /* Build configuration list for PBXProject "InAppPurchase" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 572DBB471C1A912900AF0D8F;
+			productRefGroup = 572DBB521C1A912900AF0D8F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				572DBB501C1A912900AF0D8F /* InAppPurchase */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		572DBB4F1C1A912900AF0D8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				572DBB6F1C1A917600AF0D8F /* extensions.plist in Resources */,
+				572DBB6E1C1A917600AF0D8F /* InAppPurchaseExtension.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		407AF654FA0576D5AFD2A4F7 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../../Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CB02F3C729B4AFF194701126 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		572DBB4C1C1A912900AF0D8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				572DBB6B1C1A917600AF0D8F /* ProductsRequestHelper.m in Sources */,
+				572DBB6D1C1A917600AF0D8F /* ReceiptHelper.m in Sources */,
+				579502D31C212AF400EEC9F2 /* InAppPurchaseExtension.m in Sources */,
+				572DBB691C1A917600AF0D8F /* PaymentTransactionHelper.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		572DBB571C1A912900AF0D8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		572DBB581C1A912900AF0D8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		572DBB5A1C1A912900AF0D8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BEFCD30CE59A1AA5215F83D1 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = InAppPurchase/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.crosswalk-project.IAP";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		572DBB5B1C1A912900AF0D8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A5CC6E7F0F100DA173AEFCC4 /* Pods.release.xcconfig */;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = InAppPurchase/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.crosswalk-project.IAP";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		572DBB4B1C1A912900AF0D8F /* Build configuration list for PBXProject "InAppPurchase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				572DBB571C1A912900AF0D8F /* Debug */,
+				572DBB581C1A912900AF0D8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		572DBB591C1A912900AF0D8F /* Build configuration list for PBXNativeTarget "InAppPurchase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				572DBB5A1C1A912900AF0D8F /* Debug */,
+				572DBB5B1C1A912900AF0D8F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 572DBB481C1A912900AF0D8F /* Project object */;
+}

--- a/extensions/InAppPurchase/InAppPurchase/InAppPurchase.h
+++ b/extensions/InAppPurchase/InAppPurchase/InAppPurchase.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for InAppPurchase.
+FOUNDATION_EXPORT double InAppPurchaseVersionNumber;
+
+//! Project version string for InAppPurchase.
+FOUNDATION_EXPORT const unsigned char InAppPurchaseVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <InAppPurchase/PublicHeader.h>

--- a/extensions/InAppPurchase/InAppPurchase/InAppPurchaseExtension.h
+++ b/extensions/InAppPurchase/InAppPurchase/InAppPurchaseExtension.h
@@ -1,0 +1,9 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XWalkView/XWalkExtension.h>
+
+@interface InAppPurchaseExtension : XWalkExtension
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/InAppPurchaseExtension.js
+++ b/extensions/InAppPurchase/InAppPurchase/InAppPurchaseExtension.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+var initialized = false;
+
+exports.__defineGetter__("initialized", function() {
+    return initialized;
+});
+
+function DOMError(name, message) {
+    this.name = name;
+    this.message = message;
+}
+
+exports.init = function(options) {
+    var _this = this;
+
+    return new Promise(function(resolve, reject) {
+        if (initialized)
+            throw new DOMError("InvalidStateError");
+        if (options.channel != "Apple")
+            throw new DOMError("NotSupportError");
+        options.debug = options.debug | true;
+        var resolveWrapper = function() {
+            initialized = true;
+            resolve();
+        }
+        var rejectWrapper = function() {
+            reject(new DOMError("OperationError"));
+        }
+        _this.invokeNative('init', [options, {'resolve': resolveWrapper, 'reject': rejectWrapper}]);
+    });
+}
+
+exports.queryProductsInfo = function(productIds) {
+    var _this = this;
+
+    return new Promise(function(resolve, reject) {
+        if (!initialized)
+            throw new DOMError("InvalidStateError");
+        var rejectWrapper = function(msg) {
+            reject(new DOMError("OperationError", msg));
+        }
+        _this.invokeNative('queryProductsInfo', [productIds, {'resolve': resolve, 'reject': rejectWrapper}]);
+    });
+}
+
+exports.purchase = function(order) {
+    var _this = this;
+
+    return new Promise(function(resolve, reject) {
+        if (!initialized)
+            throw new DOMError("InvalidStateError");
+        var rejectWrapper = function(msg) {
+            reject(new DOMError("OperationError", msg));
+        }
+        _this.invokeNative('purchase', [order, {'resolve': resolve, 'reject': rejectWrapper}]);
+    });
+}
+
+exports.getReceipt = function() {
+    var _this = this;
+
+    return new Promise(function(resolve, reject) {
+        if (!initialized)
+            throw new DOMError("InvalidStateError");
+        var rejectWrapper = function(msg) {
+            reject(new DOMError("OperationError", msg));
+        }
+        _this.invokeNative('getReceipt', [{'resolve': resolve, 'reject': rejectWrapper}]);
+    });
+}
+
+exports.validateReceipt = function() {
+    var _this = this;
+
+    return new Promise(function(resolve, reject) {
+        if (!initialized)
+            throw new DOMError("InvalidStateError");
+        var rejectWrapper = function(msg) {
+            reject(new DOMError("OperationError", msg));
+        }
+        _this.invokeNative('validateReceipt', [{'resolve': resolve, 'reject': rejectWrapper}]);
+    });
+}
+
+exports.restore = function() {
+    var _this = this;
+
+    return new Promise(function(resolve, reject) {
+        if (!initialized)
+            throw new DOMError("InvalidStateError");
+        var rejectWrapper = function(msg) {
+            reject(new DOMError("OperationError", msg));
+        }
+        _this.invokeNative('restore', [{'resolve': resolve, 'reject': rejectWrapper}]);
+    });
+}

--- a/extensions/InAppPurchase/InAppPurchase/InAppPurchaseExtension.m
+++ b/extensions/InAppPurchase/InAppPurchase/InAppPurchaseExtension.m
@@ -1,0 +1,172 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "InAppPurchaseExtension.h"
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+#import "PaymentTransactionHelper.h"
+#import "ProductsRequestHelper.h"
+#import "ReceiptHelper.h"
+
+@interface InAppPurchaseExtension() <PaymentTransactionHelperDelegate,
+                                     ReceiptHelperDelegate,
+                                     ProductsRequestHelperDelegate>
+
+// If this prpperty is set to YES, then the sandbox environment will be used.
+@property(nonatomic, assign) BOOL debugEnabled;
+
+@property(nonatomic, strong) ProductsRequestHelper* productRequestHelper;
+@property(nonatomic, strong) ReceiptHelper* receiptHelper;
+@property(nonatomic, strong) PaymentTransactionHelper* paymentTransactionHelper;
+
+// Methods used to hook the js interfaces.
+- (void)jsfunc_init:(NSUInteger)cid options:(NSDictionary*)options
+            promise:(NSUInteger)promise;
+- (void)jsfunc_queryProductsInfo:(NSUInteger)cid productIds:(NSArray*)productIds
+    promise:(NSUInteger)promise;
+- (void)jsfunc_purchase:(NSUInteger)cid order:(NSDictionary*)order
+    promise:(NSUInteger)promise;
+- (void)jsfunc_getReceipt:(NSUInteger)cid promise:(NSUInteger)promise;
+- (void)jsfunc_validateReceipt:(NSUInteger)cid promise:(NSUInteger)promise;
+- (void)jsfunc_restore:(NSUInteger)cid promise:(NSUInteger)promise;
+
+// Delegate methods of PaymentTransactionHelperDelegate.
+- (NSDictionary*)getProducts;
+- (void)didTransactionFinished:(NSDictionary*)transaction
+                   withPromise:(NSUInteger)promise;
+- (void)didTransactionFailedWithError:(NSError*)error
+                          withPromise:(NSUInteger)promise;
+- (void)didProductsRestored:(NSArray*)products withPromise:(NSUInteger)promise;
+- (void)didFailedRestoreWithError:(NSError*)error
+                      withPromise:(NSUInteger)promise;
+
+// Delegate methods of ProductsRequestHelperDelegate.
+- (void)didReceivedProducts:(NSArray*)products withPromise:(NSUInteger)promise;
+- (void)didRequestFailedWithError:(NSError*)error
+                      withPromise:(NSUInteger)promise;
+
+// Delegate methods of ReceiptHelperDelegate.
+- (void)didReceivedReceipt:(NSData*)receipt withPromise:(NSUInteger)promise;
+- (void)didFailedReceiptWithError:(NSError*)error withPromise:(NSUInteger)promise;
+- (void)didValidatedReceiptWithResult:(BOOL)result withPromise:(NSUInteger)promise;
+
+@end
+
+@implementation InAppPurchaseExtension
+
+- (void)jsfunc_init:(NSUInteger)cid options:(NSDictionary*)options
+    promise:(NSUInteger)promise {
+    if ([SKPaymentQueue canMakePayments]) {
+        self.debugEnabled = [[options valueForKey:@"debug"] boolValue];
+
+        self.productRequestHelper = [[ProductsRequestHelper alloc]
+            initWithIAPExtension:self];
+        self.receiptHelper = [[ReceiptHelper alloc]
+            initWithIAPExtension:self];
+        self.receiptHelper.debugEnabled = self.debugEnabled;
+        self.paymentTransactionHelper = [[PaymentTransactionHelper alloc]
+            initWithIAPExtension:self];
+        [self invokeCallback:promise key:@"resolve" arguments:nil];
+    } else {
+        [self invokeCallback:promise key:@"reject" arguments:nil];
+    }
+}
+
+- (void)jsfunc_queryProductsInfo:(NSUInteger)cid
+                      productIds:(NSArray*)productIds
+                         promise:(NSUInteger)promise {
+    [self.productRequestHelper sendRequestWithProductIds:productIds
+                                             withPromise:promise];
+}
+
+- (void)jsfunc_purchase:(NSUInteger)cid
+                  order:(NSDictionary*)order
+                promise:(NSUInteger)promise {
+    [self.paymentTransactionHelper purchase:order withPromise:promise];
+}
+
+- (void)jsfunc_getReceipt:(NSUInteger)cid promise:(NSUInteger)promise {
+    [self.receiptHelper getStoreReceiptWithPromise:promise];
+}
+
+- (void)jsfunc_validateReceipt:(NSUInteger)cid promise:(NSUInteger)promise {
+    [self.receiptHelper validateReceiptWithPromise:promise];
+}
+
+- (void)jsfunc_restore:(NSUInteger)cid promise:(NSUInteger)promise {
+    [self.paymentTransactionHelper restoreCompletedTransactionsWithPromise:promise];
+}
+
+- (void)didReceivedProducts:(NSArray*)products withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise
+                     key:@"resolve"
+               arguments:[NSArray arrayWithObjects:products, nil]];
+
+}
+
+- (void)didRequestFailedWithError:(NSError*)error
+                      withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise
+                     key:@"reject"
+               arguments:[NSArray arrayWithObjects:
+                             error.localizedDescription, nil]];
+}
+
+- (void)receiptDidFailWithError:(NSError*)error withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise
+                     key:@"reject"
+               arguments:[NSArray arrayWithObjects:
+                             error.localizedDescription, nil]];
+}
+
+- (void)didReceivedReceipt:(NSData*)receipt withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise
+                     key:@"resolve"
+               arguments:[NSArray arrayWithObjects:
+                             [receipt base64EncodedStringWithOptions:0], nil]];
+}
+
+- (void)didFailedReceiptWithError:(NSError*)error withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise key:@"reject"
+        arguments:[NSArray arrayWithObjects:error.localizedDescription, nil]];
+}
+
+- (NSDictionary*)getProducts {
+    return self.productRequestHelper.products;
+}
+
+- (void)didValidatedReceiptWithResult:(BOOL)result withPromise:(NSUInteger)promise {
+    if (result)
+        [self invokeCallback:promise key:@"resolve" arguments:nil];
+    else
+        [self invokeCallback:promise key:@"reject" arguments:nil];
+}
+
+- (void)didTransactionFinished:(NSDictionary*)transaction
+                   withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise
+                     key:@"resolve"
+               arguments:[NSArray arrayWithObjects:transaction, nil]];
+}
+
+- (void)didTransactionFailedWithError:(NSError*)error
+                          withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise key:@"reject"
+        arguments:[NSArray arrayWithObjects:error.localizedDescription, nil]];
+}
+
+- (void)didProductsRestored:(NSArray*)products withPromise:(NSUInteger)promise {
+    [self invokeCallback:promise
+                     key:@"resolve"
+               arguments:[NSArray arrayWithObjects:products, nil]];}
+
+- (void)didFailedRestoreWithError:(NSError*)error
+                      withPromise:(NSUInteger)promise{
+    [self invokeCallback:promise key:@"reject"
+        arguments:[NSArray arrayWithObjects:error.localizedDescription, nil]];
+}
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/Info.plist
+++ b/extensions/InAppPurchase/InAppPurchase/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+	<key>XWalkExtensions</key>
+	<dict>
+		<key>navigator.iap</key>
+		<string>InAppPurchaseExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/extensions/InAppPurchase/InAppPurchase/PaymentTransactionHelper.h
+++ b/extensions/InAppPurchase/InAppPurchase/PaymentTransactionHelper.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+@class  InAppPurchaseExtension;
+
+@protocol PaymentTransactionHelperDelegate
+
+@required
+- (NSDictionary*)getProducts;
+- (void)didTransactionFinished:(NSDictionary*)transaction
+                   withPromise:(NSUInteger)promise;
+- (void)didTransactionFailedWithError:(NSError*)error
+                          withPromise:(NSUInteger)promise;
+- (void)didProductsRestored:(NSArray*)products withPromise:(NSUInteger)promise;
+- (void)didFailedRestoreWithError:(NSError*)error
+                      withPromise:(NSUInteger)promise;
+
+@end
+
+@interface PaymentTransactionHelper : NSObject<SKPaymentTransactionObserver>
+
+@property(nonatomic, weak) id<PaymentTransactionHelperDelegate> delegate;
+
+- (id)initWithIAPExtension:(InAppPurchaseExtension*)extension;
+- (void)purchase:(NSDictionary*)order withPromise:(NSUInteger)promise;
+- (void)restoreCompletedTransactionsWithPromise:(NSUInteger)promise;
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/PaymentTransactionHelper.m
+++ b/extensions/InAppPurchase/InAppPurchase/PaymentTransactionHelper.m
@@ -1,0 +1,106 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "PaymentTransactionHelper.h"
+
+@interface PaymentTransactionHelper()
+
+// The array of restored products which were purchased before.
+@property(nonatomic, strong) NSMutableArray* restoredProducts;
+
+// Delegate methods of SKPaymentTransactionObserver.
+- (void)paymentQueue:(SKPaymentQueue*)queue
+ updatedTransactions:(NSArray*)transactions;
+- (void)paymentQueue:(SKPaymentQueue*)queue
+    restoreCompletedTransactionsFailedWithError:(NSError*)error;
+- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue*)queue;
+
+@end
+
+@implementation PaymentTransactionHelper {
+    // The promise ID which is used for the current request.
+    NSUInteger _promise;
+}
+
+- (id)initWithIAPExtension:(InAppPurchaseExtension*)extension {
+    if (self = [super init]) {
+        [[SKPaymentQueue defaultQueue]  addTransactionObserver:self];
+        self.delegate = (id<PaymentTransactionHelperDelegate>)extension;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+}
+
+- (void)purchase:(NSDictionary*)order withPromise:(NSUInteger)promise {
+    NSDictionary* products = [self.delegate getProducts];
+    NSString* identifier = [order valueForKey:@"productId"];
+    NSNumber* quantity = [order valueForKey:@"count"];
+    _promise = promise;
+
+    SKMutablePayment *payment =
+        [SKMutablePayment paymentWithProduct:[products objectForKey:identifier]];
+    payment.quantity = [quantity unsignedIntegerValue];
+    [[SKPaymentQueue defaultQueue] addPayment:payment];
+}
+
+- (void)restoreCompletedTransactionsWithPromise:(NSUInteger)promise {
+    _promise = promise;
+    self.restoredProducts = [[NSMutableArray alloc] init];
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
+}
+
+- (void)paymentQueue:(SKPaymentQueue*)queue
+ updatedTransactions:(NSArray*)transactions {
+    for (SKPaymentTransaction *transaction in transactions) {
+        BOOL canFinishTransaction = YES;
+
+        switch (transaction.transactionState) {
+            case SKPaymentTransactionStatePurchasing: {
+                canFinishTransaction = NO;
+                break;
+            }
+            case SKPaymentTransactionStatePurchased: {
+                NSDictionary* dictionary =
+                    [NSDictionary dictionaryWithObjectsAndKeys:
+                    transaction.payment.productIdentifier, @"productId", nil];
+                [self.delegate didTransactionFinished:dictionary
+                                          withPromise:_promise];
+                break;
+            }
+            case SKPaymentTransactionStateFailed: {
+                [self.delegate didTransactionFailedWithError:transaction.error
+                                                 withPromise:_promise];
+                break;
+            }
+            case SKPaymentTransactionStateRestored: {
+                [self.restoredProducts addObject:
+                    transaction.originalTransaction.payment.productIdentifier];
+                break;
+            }
+            default: {
+                canFinishTransaction = NO;
+                break;
+            }
+        }
+
+        if (canFinishTransaction)
+            [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+    }
+}
+
+- (void)paymentQueue:(SKPaymentQueue*)queue
+		restoreCompletedTransactionsFailedWithError:(NSError*)error {
+    [self.delegate didFailedRestoreWithError:error withPromise:_promise ];
+}
+
+- (void)paymentQueueRestoreCompletedTransactionsFinished:
+    (SKPaymentQueue*)queue {
+    [self.delegate didProductsRestored:self.restoredProducts
+                           withPromise:_promise];
+}
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/ProductsRequestHelper.h
+++ b/extensions/InAppPurchase/InAppPurchase/ProductsRequestHelper.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+@class  InAppPurchaseExtension;
+
+@protocol ProductsRequestHelperDelegate
+
+@required
+- (void)didReceivedProducts:(NSArray*)products withPromise:(NSUInteger)promise;
+- (void)didRequestFailedWithError:(NSError*)error
+                      withPromise:(NSUInteger)promise;
+
+@end
+
+@interface ProductsRequestHelper : NSObject<SKProductsRequestDelegate>
+
+@property(nonatomic, weak) id<ProductsRequestHelperDelegate> delegate;
+@property(nonatomic, strong) NSDictionary* products;
+
+- (id)initWithIAPExtension:(InAppPurchaseExtension*)extension;
+- (void)sendRequestWithProductIds:(NSArray*)productIds
+                      withPromise:(NSUInteger)promise;
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/ProductsRequestHelper.m
+++ b/extensions/InAppPurchase/InAppPurchase/ProductsRequestHelper.m
@@ -1,0 +1,72 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "ProductsRequestHelper.h"
+
+@interface ProductsRequestHelper()
+
+- (NSString*)localizedPrice:(SKProduct*)product;
+
+// Delegate methods of SKProductsRequestDelegate.
+- (void)productsRequest:(SKProductsRequest*)request
+     didReceiveResponse:(SKProductsResponse*)response;
+- (void)request:(SKRequest*)request didFailWithError:(NSError*)error;
+
+@end
+
+@implementation ProductsRequestHelper {
+    // The promise ID which is used for the current request.
+    NSUInteger _promise;
+
+    NSMutableDictionary* _products;
+}
+
+@synthesize products = _products;
+
+- (id)initWithIAPExtension:(InAppPurchaseExtension*)extension {
+    if (self = [super init]) {
+        self.products = [[NSMutableDictionary alloc] init];
+        self.delegate = (id<ProductsRequestHelperDelegate>)extension;
+    }
+    return self;
+}
+
+- (void)sendRequestWithProductIds:(NSArray*)productIds
+                      withPromise:(NSUInteger)promise {
+    SKProductsRequest* request = [[SKProductsRequest alloc]
+        initWithProductIdentifiers:[NSSet setWithArray:productIds]];
+    request.delegate = self;
+    _promise = promise;
+    [request start];
+}
+
+- (void)productsRequest:(SKProductsRequest*)request
+     didReceiveResponse:(SKProductsResponse*)response {
+    NSMutableArray* products = [NSMutableArray array];
+    for (SKProduct* product in response.products) {
+        [_products setObject:product forKey:product.productIdentifier];
+        NSDictionary* dictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+            product.productIdentifier, @"productId",
+            product.localizedTitle, @"title",
+            product.localizedDescription, @"description",
+            [self localizedPrice:product], @"price",
+            nil];
+        [products addObject:dictionary];
+    }
+    [self.delegate didReceivedProducts:products withPromise:_promise];
+}
+
+- (void)request:(SKRequest*)request didFailWithError:(NSError*)error {
+    [self.delegate didRequestFailedWithError:error withPromise:_promise];
+}
+
+- (NSString*)localizedPrice:(SKProduct*)product {
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+    [numberFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
+    [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
+    [numberFormatter setLocale:product.priceLocale];
+    return [numberFormatter stringFromNumber:product.price];
+}
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/ReceiptHelper.h
+++ b/extensions/InAppPurchase/InAppPurchase/ReceiptHelper.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+@class  InAppPurchaseExtension;
+
+@protocol ReceiptHelperDelegate
+
+@required
+- (void)didReceivedReceipt:(NSData*)receipt withPromise:(NSUInteger)promise;
+- (void)didFailedReceiptWithError:(NSError*)error withPromise:(NSUInteger)promise;
+- (void)didValidatedReceiptWithResult:(BOOL)result withPromise:(NSUInteger)promise;
+
+@end
+
+@interface ReceiptHelper : NSObject<SKRequestDelegate>
+
+@property(nonatomic, weak) id<ReceiptHelperDelegate> delegate;
+@property(nonatomic, assign) BOOL debugEnabled;
+
+- (id)initWithIAPExtension:(InAppPurchaseExtension*)extension;
+- (void)getStoreReceiptWithPromise:(NSUInteger)promise;
+- (void)validateReceiptWithPromise:(NSUInteger)promise;
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/ReceiptHelper.m
+++ b/extensions/InAppPurchase/InAppPurchase/ReceiptHelper.m
@@ -1,0 +1,129 @@
+// Copyright (c) 2015 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "ReceiptHelper.h"
+
+#import <StoreKit/StoreKit.h>
+
+NSString* const kSandboxUrl = @"https://sandbox.itunes.apple.com/verifyReceipt";
+NSString* const kProductUrl = @"https://buy.itunes.apple.com/verifyReceipt";
+
+@interface ReceiptHelper()
+
+- (NSData*)getStoreReceipt;
+- (void)refreshReceipt;
+- (void)validateReceipt:(NSData*)receipt;
+
+// Delegate methods of SKRequestDelegate.
+- (void)requestDidFinish:(SKRequest*)request;
+- (void)request:(SKRequest*)request didFailWithError:(NSError*)error;
+
+@end
+
+@implementation ReceiptHelper {
+    // The promise ID which is used for the current request.
+    NSUInteger _promise;
+
+    BOOL _validatingReceipt;
+    SKReceiptRefreshRequest* _request;
+}
+
+- (id)initWithIAPExtension:(InAppPurchaseExtension*)extension {
+    if (self = [super init]) {
+        self.delegate = (id<ReceiptHelperDelegate>)extension;
+    }
+    return self;
+}
+
+- (void)getStoreReceiptWithPromise:(NSUInteger)promise {
+    _promise = promise;
+    [self refreshReceipt];
+}
+
+- (NSData*)getStoreReceipt {
+    NSBundle *bundle = [NSBundle mainBundle];
+    NSURL* receiptURL = [bundle performSelector:@selector(appStoreReceiptURL)];
+    return [NSData dataWithContentsOfURL:receiptURL];
+}
+
+- (void)refreshReceipt {
+    _request = [[SKReceiptRefreshRequest alloc] init];
+    _request.delegate = self;
+    [_request start];
+}
+
+- (void)requestDidFinish:(SKRequest*)request {
+    if (_validatingReceipt) {
+        [self validateReceipt:[self getStoreReceipt]];
+    } else {
+        [self.delegate didReceivedReceipt:[self getStoreReceipt]
+                              withPromise:_promise];
+    }
+}
+
+- (void)request:(SKRequest*)request didFailWithError:(NSError*)error {
+    if (_validatingReceipt) {
+        [self.delegate didValidatedReceiptWithResult:NO withPromise:_promise];
+        _validatingReceipt = NO;
+    } else {
+        [self.delegate didFailedReceiptWithError:error withPromise:_promise];
+    }
+}
+
+- (void)validateReceiptWithPromise:(NSUInteger)promise {
+    _promise = promise;
+    _validatingReceipt = YES;
+    [self refreshReceipt];
+}
+
+- (void)validateReceipt:(NSData*)receipt {
+    NSError *error = nil;
+    NSString* base64 = [receipt base64EncodedStringWithOptions:0];
+    NSDictionary* requestContents = @{ @"receipt-data": base64 };
+    NSData* requestData =
+        [NSJSONSerialization dataWithJSONObject:requestContents
+                                        options:0
+                                          error:&error];
+    NSURL* url = nil;
+    if (self.debugEnabled)
+        url = [NSURL URLWithString:kSandboxUrl];
+    else
+        url = [NSURL URLWithString:kProductUrl];
+
+    if (requestData) {
+        NSMutableURLRequest* request =
+            [NSMutableURLRequest requestWithURL:url];
+        [request setHTTPMethod:@"POST"];
+        [request setHTTPBody:requestData];
+        NSURLSession *session = [NSURLSession sharedSession];
+        [[session dataTaskWithRequest:request
+            completionHandler:^(NSData *data,
+                                NSURLResponse *response,
+                                NSError *error) {
+                _validatingReceipt = NO;
+
+                if (!error) {
+                    NSError* jsonError = nil;
+                    NSDictionary* jsonResponse =
+                        [NSJSONSerialization JSONObjectWithData:data
+                                                        options:0
+                                                          error:&jsonError];
+                    NSInteger status =
+                        [[jsonResponse valueForKey:@"status"] integerValue];
+                    if (status == 0) {
+                        [self.delegate didValidatedReceiptWithResult:YES
+                                                         withPromise:_promise];
+                        return;
+                    }
+                }
+                [self.delegate didValidatedReceiptWithResult:NO
+                                                 withPromise:_promise];
+            }] resume];
+    } else {
+        _validatingReceipt = NO;
+        [self.delegate didValidatedReceiptWithResult:NO withPromise:_promise];
+    }
+}
+
+@end

--- a/extensions/InAppPurchase/InAppPurchase/extensions.plist
+++ b/extensions/InAppPurchase/InAppPurchase/extensions.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>XWalkExtensions</key>
+	<dict>
+		<key>navigator.iap</key>
+		<string>InAppPurchaseExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/iOSExtensions.xcworkspace/contents.xcworkspacedata
+++ b/iOSExtensions.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:extensions/InAppPurchase/InAppPurchase.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:extensions/Cordova/Cordova.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
This patch implements the in-app purchase (IAP) on iOS. By enabling
this, developers who use the crosswalk framework, can call the
javascript methods to buy virtual goods on Apple Store.

BUG=XWALK-5698
