### PR TITLE
[Fingerprint]Implement the fingerprint authentication on iOS

### DIFF
--- a/crosswalk-extension-fingerprint.podspec
+++ b/crosswalk-extension-fingerprint.podspec
@@ -1,0 +1,23 @@
+# Copyright (c) 2016 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+Pod::Spec.new do |s|
+  s.name             = 'crosswalk-extension-fingerprint'
+  s.version          = '1.3'
+  s.summary          = 'Fingerprint extension is a Crosswalk extension which implements touchID authentication on iOS'
+  s.homepage         = 'https://github.com/crosswalk-project/ios-extensions-crosswalk/tree/master/extensions/Fingerprint'
+  s.license          = { :type => 'BSD', :file => "LICENSE" }
+  s.author           = { 'Minggang Wang' => 'minggang.wang@intel.com' }
+  s.source           = { :git => 'https://github.com/crosswalk-project/ios-extensions-crosswalk.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/xwalk_project'
+
+  s.platform = :ios, '8.1'
+  s.ios.deployment_target = '8.1'
+  s.module_name = 'Fingerprint'
+  s.dependency 'crosswalk-ios', '~> 1.2'
+
+  s.source_files = 'extensions/Fingerprint/Fingerprint/*.{h,m,swift}'
+  s.resource = 'extensions/Fingerprint/Fingerprint/*.js', 'extensions/Fingerprint/Fingerprint/extensions.plist'
+
+end

--- a/extensions/Fingerprint/Fingerprint.xcodeproj/project.pbxproj
+++ b/extensions/Fingerprint/Fingerprint.xcodeproj/project.pbxproj
@@ -1,0 +1,302 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57F3D3AC1C5A05BB00166B7A /* Fingerprint.h in Headers */ = {isa = PBXBuildFile; fileRef = 57F3D3AB1C5A05BB00166B7A /* Fingerprint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		57F3D3B71C5A086F00166B7A /* FingerprintExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 57F3D3B51C5A086F00166B7A /* FingerprintExtension.h */; };
+		57F3D3B81C5A086F00166B7A /* FingerprintExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 57F3D3B61C5A086F00166B7A /* FingerprintExtension.m */; };
+		57F3D3E41C5A20D800166B7A /* extensions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 57F3D3E31C5A20D800166B7A /* extensions.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		57F3D3A81C5A05BB00166B7A /* Fingerprint.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Fingerprint.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		57F3D3AB1C5A05BB00166B7A /* Fingerprint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fingerprint.h; sourceTree = "<group>"; };
+		57F3D3AD1C5A05BB00166B7A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		57F3D3B51C5A086F00166B7A /* FingerprintExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FingerprintExtension.h; sourceTree = "<group>"; };
+		57F3D3B61C5A086F00166B7A /* FingerprintExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FingerprintExtension.m; sourceTree = "<group>"; };
+		57F3D3E31C5A20D800166B7A /* extensions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = extensions.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57F3D3A41C5A05BB00166B7A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57F3D39E1C5A05BA00166B7A = {
+			isa = PBXGroup;
+			children = (
+				57F3D3AA1C5A05BB00166B7A /* Fingerprint */,
+				57F3D3A91C5A05BB00166B7A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57F3D3A91C5A05BB00166B7A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57F3D3A81C5A05BB00166B7A /* Fingerprint.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57F3D3AA1C5A05BB00166B7A /* Fingerprint */ = {
+			isa = PBXGroup;
+			children = (
+				57F3D3B91C5A08CF00166B7A /* Supporting Files */,
+				57F3D3AB1C5A05BB00166B7A /* Fingerprint.h */,
+				57F3D3B51C5A086F00166B7A /* FingerprintExtension.h */,
+				57F3D3B61C5A086F00166B7A /* FingerprintExtension.m */,
+				57F3D3E31C5A20D800166B7A /* extensions.plist */,
+			);
+			path = Fingerprint;
+			sourceTree = "<group>";
+		};
+		57F3D3B91C5A08CF00166B7A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				57F3D3AD1C5A05BB00166B7A /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		57F3D3A51C5A05BB00166B7A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57F3D3AC1C5A05BB00166B7A /* Fingerprint.h in Headers */,
+				57F3D3B71C5A086F00166B7A /* FingerprintExtension.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		57F3D3A71C5A05BB00166B7A /* Fingerprint */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57F3D3B01C5A05BB00166B7A /* Build configuration list for PBXNativeTarget "Fingerprint" */;
+			buildPhases = (
+				57F3D3A31C5A05BB00166B7A /* Sources */,
+				57F3D3A41C5A05BB00166B7A /* Frameworks */,
+				57F3D3A51C5A05BB00166B7A /* Headers */,
+				57F3D3A61C5A05BB00166B7A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Fingerprint;
+			productName = Fingerprint;
+			productReference = 57F3D3A81C5A05BB00166B7A /* Fingerprint.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57F3D39F1C5A05BA00166B7A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = intel;
+				TargetAttributes = {
+					57F3D3A71C5A05BB00166B7A = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = 57F3D3A21C5A05BA00166B7A /* Build configuration list for PBXProject "Fingerprint" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 57F3D39E1C5A05BA00166B7A;
+			productRefGroup = 57F3D3A91C5A05BB00166B7A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57F3D3A71C5A05BB00166B7A /* Fingerprint */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		57F3D3A61C5A05BB00166B7A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57F3D3E41C5A20D800166B7A /* extensions.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57F3D3A31C5A05BB00166B7A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57F3D3B81C5A086F00166B7A /* FingerprintExtension.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		57F3D3AE1C5A05BB00166B7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		57F3D3AF1C5A05BB00166B7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		57F3D3B11C5A05BB00166B7A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Fingerprint/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.crosswalk-project.Fingerprint";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		57F3D3B21C5A05BB00166B7A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Fingerprint/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.crosswalk-project.Fingerprint";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57F3D3A21C5A05BA00166B7A /* Build configuration list for PBXProject "Fingerprint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57F3D3AE1C5A05BB00166B7A /* Debug */,
+				57F3D3AF1C5A05BB00166B7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57F3D3B01C5A05BB00166B7A /* Build configuration list for PBXNativeTarget "Fingerprint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57F3D3B11C5A05BB00166B7A /* Debug */,
+				57F3D3B21C5A05BB00166B7A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57F3D39F1C5A05BA00166B7A /* Project object */;
+}

--- a/extensions/Fingerprint/Fingerprint/Fingerprint.h
+++ b/extensions/Fingerprint/Fingerprint/Fingerprint.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Fingerprint.
+FOUNDATION_EXPORT double FingerprintVersionNumber;
+
+//! Project version string for Fingerprint.
+FOUNDATION_EXPORT const unsigned char FingerprintVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Fingerprint/PublicHeader.h>

--- a/extensions/Fingerprint/Fingerprint/FingerprintExtension.h
+++ b/extensions/Fingerprint/Fingerprint/FingerprintExtension.h
@@ -1,0 +1,9 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XWalkView/XWalkExtension.h>
+
+@interface FingerprintExtension : XWalkExtension
+
+@end

--- a/extensions/Fingerprint/Fingerprint/FingerprintExtension.m
+++ b/extensions/Fingerprint/Fingerprint/FingerprintExtension.m
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FingerprintExtension.h"
+
+@import LocalAuthentication;
+
+@interface FingerprintExtension()
+
+- (void)jsfunc_authenticate:(NSUInteger)cid
+                     reason:(NSString*)reason
+                   _Promise:(NSUInteger)promise;
+
+@end
+
+@implementation FingerprintExtension
+
+- (void)jsfunc_authenticate:(NSUInteger)cid
+                     reason:(NSString*)reason
+                   _Promise:(NSUInteger)promise {
+    LAContext* context = [[LAContext alloc] init];
+    NSError* error = nil;
+    BOOL canAuthenticate = NO;
+
+    canAuthenticate = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                                           error:&error];
+    if (!canAuthenticate) {
+        NSDictionary* arg = [NSDictionary dictionaryWithObjectsAndKeys:
+            @"NotSupportError", @"name", nil];
+        [self invokeCallback:promise key:@"reject" arguments:[NSArray arrayWithObjects:arg, nil]];
+        return;
+    }
+
+    [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+            localizedReason:reason
+                      reply:^(BOOL success, NSError* authenticationError) {
+        if (success) {
+           [self invokeCallback:promise key:@"resolve" arguments:nil];
+        } else {
+           NSDictionary* arg = [NSDictionary dictionaryWithObjectsAndKeys:
+               @"OperationError", @"name", authenticationError.localizedDescription, @"message", nil];
+           [self invokeCallback:promise key:@"reject" arguments:[NSArray arrayWithObjects:arg, nil]];
+        }
+    }];
+}
+
+@end

--- a/extensions/Fingerprint/Fingerprint/Info.plist
+++ b/extensions/Fingerprint/Fingerprint/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>XWalkExtensions</key>
+	<dict>
+		<key>xwalk.experimental.fingerprint</key>
+		<string>FingerprintExtension</string>
+	</dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/extensions/Fingerprint/Fingerprint/extensions.plist
+++ b/extensions/Fingerprint/Fingerprint/extensions.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>XWalkExtensions</key>
+	<dict>
+		<key>xwalk.experimental.fingerprint</key>
+		<string>FingerprintExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/iOSExtensions.xcworkspace/contents.xcworkspacedata
+++ b/iOSExtensions.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:extensions/Fingerprint/Fingerprint.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:extensions/InAppPurchase/InAppPurchase.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
This patch implements the fingerprint, aka TouchID, as a
local authentication method on iOS. Developer can call the javascript
interface:
    xwalk.experimental.fingerprint.authenticate();
to start the sensor to authenticate.

BUG=XWALK-6221
