### PR TITLE
[IAP][Spec]Change the status of the IAP spec

### DIFF
--- a/extensions/InAppPurchase/spec/iap.html
+++ b/extensions/InAppPurchase/spec/iap.html
@@ -9,15 +9,12 @@
             async class='remove'></script>
     <script class="remove">
     var respecConfig = {
-        specStatus: 'ED',
-        edDraftURI: 'http://10.238.157.53/html/iap.html',
+        specStatus: 'unofficial',
         shortName:  'IAP-api',
         editors: [
           {
-            w3cid: 63802,
             name: 'Minggang Wang',
             company: 'Intel',
-            note: 'until Nov 2015'
           }
         ],
         previousMaturity: 'WD',


### PR DESCRIPTION
As the spec is unofficial, change the status to 'unofficial' in the
respec config.
